### PR TITLE
Changed Access private to Administration access

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 	- [Upgrading](installation/upgrading.md)
 
 * [Getting started](getting started/index.md)
-	- [Access private](getting started/index.md)
+	- [Administration access](getting started/index.md)
 	- [Adding modules](getting started/adding_modules.md)
 	- [Adding a theme](getting started/adding_a_theme.md)
 	- [Spam protection](getting started/spam_protection.md)


### PR DESCRIPTION
The wording _Administration access_ is easier to understand than _Access private_.

Maybe the wording should really be _Access to administrative functions_, but this might be too verbose.
