### PR TITLE
Remove $uri/ from the Nginx rewrite

### DIFF
--- a/installation/webservers.md
+++ b/installation/webservers.md
@@ -62,12 +62,12 @@ server {
   index index.html index.php;
   
   location / {
-  	try_files $uri $uri/ /index.php?$args;
+  	try_files $uri /index.php?$args;
   }
   
   location ~ ^/(backend|install|api(\/\d.\d)?(\/client)?).*\.php$ {
   	# backend/install/api are existing dirs, but should all pass via the front
-  	try_files $uri $uri/ /index.php?$args;
+  	try_files $uri /index.php?$args;
   }
   
   location ~ ^(.+\.php)(.*)$ {


### PR DESCRIPTION
$uri/ (with the trailing slash) is a "directory exists" check. If the directory exists, it's used as a destination -- that's not what you want in this case