### PR TITLE
Update webservers doc with nginx config

### DIFF
--- a/01. installation/04. webservers.md
+++ b/01. installation/04. webservers.md
@@ -141,3 +141,24 @@ A summary of the changes that you should be making are:
 * Change the value of the `root` directive to point to the correct location of your website, such as `/var/www/html/fork-cms`.
 * Change the value of the server_name directive to point to your domain name or IP address.
 * Make sure you check if `fastcgi_pass` is set correctly. For PHP7 this will probably be `unix:/var/run/php/php7.0-fpm.sock`. 
+
+Some of these might already be set from your LEMP installation. You can save and close the file. Now we still need to activate our website configuration by linking the file to the `sites-enabled` directory. We can do the following:
+
+```
+sudo ln -s /etc/nginx/sites-available/fork-cms /etc/nginx/sites-enabled/
+```
+
+Our new file conflicts with the old default file, since it borrowed much. We can disable the default file by removing it from the `sites-enabled` folder:
+
+```
+sudo rm /etc/nginx/sites-enabled/default
+```
+
+Now, we only need to restart Nginx and PHP to enable our changes:
+
+```
+sudo service nginx restart
+sudo service php5-fpm restart
+```
+
+Point your browser to your server's domain or IP and see if you can view your Fork CMS website. You may have to refresh the page and clear the cache. If for some reason, the website is not loading correctly, you can checkout the `error_log` or `access_log` that you configured on top in your configuration file.  

--- a/01. installation/04. webservers.md
+++ b/01. installation/04. webservers.md
@@ -1,6 +1,6 @@
-# Alternative webservers
+# Webservers
 
-To be a lean, mean, SEO-machine, Fork CMS uses url-rewriting to form a proper url-structure for your website. Fork CMS has been configured to work well with Apache out of the box, but it can run perfectly on other servers as well (such as Lighttpd and Nginx).
+To be a lean, mean, SEO-machine, Fork CMS uses url-rewriting to form a proper url-structure for your website. Fork CMS has been configured to work well with Apache out of the box, but it can run perfectly on other servers as well (such as Nginx).
 
 ## Apache
 
@@ -16,97 +16,128 @@ If you see an internal server error, it is possible that your webserver does not
 Options +FollowSymlinks -Indexes
 ```
 
-## Lighttpd
-
-On Apache the .htaccess-file instructs all incoming urls to be parsed by index.php. The Lighttpd-config should reflect this. Here's a sample configuration example:
-
-```
-server.modules = (
- "mod_rewrite",
- ...
-)
-...
-
-## Fork-CMS
-$HTTP["host"] =~ "(mydomain.com)" {
-server.document-root = "/path/to/forkcms"
-dir-listing.activate = "disable"
-setenv.add-environment = ( "MOD_REWRITE" => "1")
-
-url.rewrite-if-not-file = ( "^/?$" => "$0",
-                "^/(backend|install|api(\/\d.\d)?(\/client)?)/(.*)" => "/index.php/$0",
-                "^/(?!(backend|install|api(\/\d.\d)?(\/client)?))(.+)/?$" => "/index.php/$0"
-               )
-
-}
-```
-
-In this sample configuration, Fork CMS needs to rewrite its urls. This rewrite rule is based on the Apache .htaccess-file and should work with the latest Lighttpd 1.4.x without causing a redirect loop.
-
-These are the minimal requirements for Fork CMS to function properly with regards to configuring Lighttpd as your webserver.
-
-Additional configuration options can be added to Lighttpd's configuration file to approximate the behaviour under Apache with regards to caching, compression, and so on.
-
 ## Nginx
 
-Another popular lightweight webserver is Nginx. The configuration of this server for Fork CMS is similar to the configuration on a Lighttpd server. Below you can find an example configuration.
+Nginx is a powerful and efficient web server that has seen wide adoption due to its performance capabilities. The configuration of this server does not happen through the .htaccess file (typically Apache), but through a dedicated config file on the server.  
+
+In order for Nginx to serve the Fork CMS website correctly, we need to create a new server block. We can use the default nginx server block as a base. Copy it over like this:
+
+```
+sudo cp /etc/nginx/sites-available/default /etc/nginx/sites-available/fork-cms
+```
+
+Open the new file we made so that we can make some changes:
+
+```
+sudo nano /etc/nginx/sites-available/fork-cms
+```
+
+Below you can find an example configuration for Fork CMS:
 
 ```
 server {
-  listen       80;
+    listen 80;
 
-  server_name mydomain.com;
-  server_name_in_redirect off;
-  root /path/to/fork;
+    root /path/to/documentroot/;
+    index index.php index.html index.htm;
 
-  index index.html index.php;
-  
-  location / {
-  	try_files $uri $uri/ /index.php?$args;
-  }
-  
-  location ~ ^/(backend|install|api(\/\d.\d)?(\/client)?).*\.php$ {
-  	# backend/install/api are existing dirs, but should all pass via the front
-  	try_files $uri $uri/ /index.php?$args;
-  }
-  
-  location ~ ^(.+\.php)(.*)$ {
-    include fastcgi_params;
-    fastcgi_pass 127.0.0.1:9000;
-    fastcgi_index index.php;
-  }
+    server_name  example.com www.example.com;
 
-  # gzip
-  gzip on;
-  gzip_disable "MSIE [1-6]\.(?!.*SV1)"; # disables gzip compression for browsers that don't support it (in this case MS Internet Explorer before version 6 SV1).
-  gzip_http_version 1.1;
-  gzip_vary on; # This sets the response header Vary: Accept-Encoding. Some proxies have a bug in that they serve compressed content to browsers that don't support it. By setting the Vary: Accept-Encoding header, you instruct proxies to store both a compressed and uncompressed version of the content.
-  gzip_comp_level 6;
-  gzip_proxied any;
-  gzip_types text/plain text/html text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript text/x-js ;
-  gzip_buffers 16 8k;
+    error_log  /var/log/nginx/example.com/default_error.log;
+    access_log  /var/log/nginx/example.com/default_access.log;
 
-  # client caching
-  location ~ \.(css|js|html|htm|rtf|rtx|svg|svgz|txt|xsd|xsl|xml|asf|asx|wax|wmv|wmx|avi|bmp|class|divx|doc|docx|exe|gif|gz|gzip|ico|jpg|jpeg|jpe|mdb|mid|midi|mov|qt|mp3|m4a|mp4|m4v|mpeg|mpg|mpe|mpp|odb|odc|odf|odg|odp|ods|odt|ogg|pdf|png|pot|pps|ppt|pptx|ra|ram|swf|tar|tif|tiff|wav|wma|woff|wri|xla|xls|xlsx|xlt|xlw|zip)$ {
-    expires 31d;
-    add_header Pragma "public";
-    add_header Cache-Control "public, must-revalidate, proxy-revalidate";
-  }
-  ...
+    location / {
+        # Checks whether the requested URL exists as a file ($uri) or directory ($uri/) in the root, else redirect to /index.php.
+        try_files $uri $uri/ @redirects;
+    }
+
+    location @redirects {
+        rewrite ^ /index.php;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        include fastcgi_params;
+        fastcgi_pass unix:/var/run/php5-fpm.sock; # Make sure to doublecheck this!
+        fastcgi_index index.php;
+        fastcgi_read_timeout 60;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+        # Enable Fork Debug mode
+        # fastcgi_param FORK_DEBUG "1";
+    }
+
+    # Don't pollute the logs with common requests
+    location = /robots.txt  { access_log off; log_not_found off; }
+    location = /favicon.ico { access_log off; log_not_found off; }
+
+
+    ##########################
+    # Security
+    ##########################
+    # Hide Nginx version in headers
+    server_tokens off; 
+
+    # As Fork CMS has the app_root as doc_root, we need to restrict access to a few things for security purposes!
+    location ~* ^/(composer\..*|vendor\/.*|Procfile$|\.git\/.*|src\/Console.*|.*\.gitignore|\.editorconfig|\.travis.yml|autoload\.php|bower\.json|phpunit\.xml\.dist|.*\.md|app\/logs\/.*|app\/config\/.*|src\/Frontend\/Cache\/CompiledTemplates.*|src\/Frontend\/Cache\/Locale\/.*\.php|src\/Frontend\/Cache\/Navigation\/.*\.php|src\/Frontend\/Cache\/Search\/.*|src\/Backend\/Cache\/CompiledTemplates\/.*|src\/Backend\/Cache\/Locale\/.*\.php)$ {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+
+    # Deny access to dot-files.
+    location ~ /\. {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+
+    # Enable this if you want custom error pages
+    # error_page   500 502 503 504  /50x.html;
+    #     location = /50x.html {
+    #     root html;
+    # }
+
+
+    ##########################
+    # Additional Nginx Tweaks
+    # Read more: https://www.digitalocean.com/community/tutorials/how-to-optimize-nginx-configuration
+    # Read more: https://www.nginx.com/blog/9-tips-for-improving-wordpress-performance-with-nginx/
+    ##########################
+    # Buffers
+    client_body_buffer_size 10K; # Handles the client buffer size, meaning any POST actions like form submissions.
+    client_header_buffer_size 1k; # Handles the client header size. 1K is a decent size. 
+    client_max_body_size 50M; # The maximum allowed size of a request. If exceeded, Nginx throws a 413 Request Entity Too Large.
+    large_client_header_buffers 2 1k; # The max number and size of buffers for large client headers.
+
+    # Timeouts
+    client_body_timeout 12; # Time a server will wait for a client body to be sent after request.
+    client_header_timeout 12; # Time a server will wait for a client header to be sent after request.
+    keepalive_timeout 15; # Timeout for keep-alive connections. After this period of time, the connection is closed.
+    send_timeout 10; # If after this time, the client will take nothing, then Nginx shuts down the connection.
+
+    # Gzip compression
+    gzip on;
+    gzip_comp_level 6;  # Compression level, 1-9. Higher means smaller files, but wasting more CPU cycles.
+    gzip_min_length 1000; # Minimum file size in bytes (really small files aren’t worth compressing)
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+    gzip_buffers 4 32k;
+    gzip_vary on;
+
+    # Static file caching
+    # Set expires headers for files that don't change often and are served regularly, and turn off 404 error logging.
+    location ~* \.(?:ogg|ogv|svg|svgz|eot|otf|woff|mp4|ttf|css|js|rss|atom|jpg|jpeg|gif|png|ico|zip|tgz|gz|rar|bz2|doc|xls|exe|ppt|tar|mid|midi|wav|bmp|rtf)$ {
+        expires 1y;
+        access_log off;
+        log_not_found off;
+    }
 }
 ```
 
-## Cherokee
+A summary of the changes that you should be making are:
 
-To get Fork CMS working properly Cherokee needs to redirect the request made by the users' browsers. To do this one must edit the default rule of the vhost then add two new rules. Instructions:
-
-1. Open Cherokee Admin
-2. Open the behavior settings for the vhost
-3. Change the handler of the default rule to “Redirection”
-4. Click the “Add New RegEx” button
-5. Set type to internal, leave regular expression blank, and set substitution to “/index.php”
-6. Create two directory rules: /frontend and /backend (both are Final)
-7. Set the handlers of those two rules to “List & Send”
-8. Make sure the Directory Rules are under the static content and PHP rules
-9. Save the configuration then restart the server.
-10. All credits to arch_is_awesome.
+* Change the value of the `root` directive to point to the correct location of your website, such as `/var/www/html/fork-cms`.
+* Change the value of the server_name directive to point to your domain name or IP address.
+* Make sure you check if `fastcgi_pass` is set correctly. For PHP7 this will probably be `unix:/var/run/php/php7.0-fpm.sock`. 


### PR DESCRIPTION
Nginx configuration was very outdated. Normally this will be a decent configuration now. I tried it out on https://dokku.jessedobbelae.re/

I also removed Lighttpd and cherokee. Why? They're almost never used anymore. See this:

![Usage 2016](https://w3techs.com/diagram/market_technology/ws-apache,ws-lighttpd,ws-nginx)

![Usage 2012](http://royal.pingdom.com/wp-content/uploads/2012/05/web-server-stats-1024px.png)

Also: https://news.netcraft.com/archives/2010/11/05/november-2010-web-server-survey.html usage was 0.59% of Lighttpd and in 2016 they are not even anymore in the statistics: https://news.netcraft.com/archives/2016/09/19/september-2016-web-server-survey.html